### PR TITLE
fix: if definition bracket breaks USE_RTZERO_TIME

### DIFF
--- a/ThriftyCounter.ino
+++ b/ThriftyCounter.ino
@@ -217,8 +217,8 @@ DateTime getCurrentTime() {
 #endif
 #if defined(USE_DS3231_TIME) 
   return rtc.now();
-}
 #endif
+}
 
 //
 // Compute a FAT filename for the events log


### PR DESCRIPTION
If you want to use USE_RTCZERO_TIME, like I do, the `getCurrentTime` function breaks due to a misaligned bracket. This fixes it. 